### PR TITLE
Hide `liftCallCC` from `Control.Monad.Cont.Class`

### DIFF
--- a/library/MTLPrelude.hs
+++ b/library/MTLPrelude.hs
@@ -14,6 +14,7 @@ where
 
 import Control.Monad.Cont.Class
   as Exports
+  hiding (liftCallCC)
 
 import Control.Monad.Trans.Cont
   as Exports

--- a/mtl-prelude.cabal
+++ b/mtl-prelude.cabal
@@ -52,8 +52,8 @@ library
   exposed-modules:
     MTLPrelude
   build-depends:
-    transformers >= 0.4 && < 0.6,
-    mtl == 2.2.*,
+    transformers >= 0.4 && < 0.7,
+    mtl >= 2.2 && < 2.4,
     base < 5
   default-extensions:
     NoImplicitPrelude


### PR DESCRIPTION
`liftCallCC` is newly exported in mtl 2.3.1.